### PR TITLE
feat: Add Gradio proof-of-concept for AI email analysis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scikit-learn
 joblib
 psycopg2-binary
 pyngrok>=0.7.0
+gradio

--- a/server/python_backend/README.md
+++ b/server/python_backend/README.md
@@ -1,0 +1,33 @@
+# Python Backend README
+
+This directory contains the Python backend services for the application.
+
+## Gradio Interface
+
+A Gradio interface is available for interacting with some of the backend functionalities.
+Currently, it supports:
+- **AI Email Analysis**: Input an email's subject and content to get an AI-powered analysis.
+
+### Running the Gradio App
+
+1.  **Ensure dependencies are installed:**
+    ```bash
+    pip install -r requirements.txt
+    # (Make sure you are in the root directory of the project or adjust path to requirements.txt)
+    ```
+    Alternatively, if you have `uv` installed:
+    ```bash
+    uv pip install -r requirements.txt
+    ```
+
+2.  **Navigate to the Python backend directory:**
+    ```bash
+    cd server/python_backend
+    ```
+
+3.  **Run the Gradio app:**
+    ```bash
+    python gradio_app.py
+    ```
+
+4.  The interface will typically be available at `http://127.0.0.1:7860` (or the next available port). Check the console output for the exact URL.

--- a/server/python_backend/gradio_app.py
+++ b/server/python_backend/gradio_app.py
@@ -1,0 +1,30 @@
+import gradio as gr
+from server.python_backend.ai_engine import AdvancedAIEngine # Assuming ai_engine.py is in the same directory
+
+# Initialize the AI Engine
+ai_engine = AdvancedAIEngine()
+
+def analyze_email_interface(subject, content):
+    """
+    Analyzes email subject and content using AdvancedAIEngine.
+    Returns the AIAnalysisResult as a dictionary (Gradio handles JSON conversion).
+    """
+    email_data = {"subject": subject, "content": content}
+    ai_result = ai_engine.analyze_email(email_data)
+    return ai_result.model_dump()  # Convert Pydantic model to dict for Gradio
+
+# Create the Gradio interface
+iface = gr.Interface(
+    fn=analyze_email_interface,
+    inputs=[
+        gr.Textbox(lines=2, placeholder="Enter Email Subject Here...", label="Subject"),
+        gr.Textbox(lines=5, placeholder="Enter Email Content Here...", label="Content")
+    ],
+    outputs=gr.JSON(label="AI Analysis Result"),
+    title="Email Analyzer AI",
+    description="Analyzes email subject and content using an advanced AI engine."
+)
+
+# Launch the Gradio app
+if __name__ == "__main__":
+    iface.launch()


### PR DESCRIPTION
This commit introduces a Gradio interface for the Python backend, allowing interactive testing and demonstration of AI functionalities.

Key changes:
- Added `gradio` to `requirements.txt`.
- Created `server/python_backend/gradio_app.py`:
    - Implements a Gradio interface for the `AdvancedAIEngine.analyze_email` function.
    - You can input an email subject and content.
    - The AI analysis result (topic, sentiment, intent, etc.) is displayed.
- Created `server/python_backend/README.md`:
    - Provides documentation for the Python backend.
    - Includes instructions on how to install dependencies and run the Gradio app.

The Gradio app runs as a separate service, typically on `http://127.0.0.1:7860`. This initial PoC helps in visualizing and interacting with the AI engine's capabilities directly.