### PR TITLE
Fix: Ensure launch.py propagates errors and refactor env management

### DIFF
--- a/deployment/models.py
+++ b/deployment/models.py
@@ -19,9 +19,6 @@ import shutil
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple, Union
 
-# Import environment manager
-from deployment.env_manager import env_manager
-
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
@@ -39,7 +36,6 @@ class ModelsManager:
         """Initialize the models manager."""
         self.root_dir = root_dir
         self.models_dir = root_dir / "models"
-        self.env_manager = env_manager
         
         # Create the models directory if it doesn't exist
         if not self.models_dir.exists():


### PR DESCRIPTION
This commit addresses an issue where `launch.bat` would exit silently without indicating an error if `launch.py` encountered a problem, particularly if a subprocess managed by `launch.py` failed after starting.

Changes include:

1.  **Error Propagation in `launch.py`**:
    *   I modified `run_application` to detect unexpected exits of backend or frontend services.
    *   I ensured `launch.py` returns a non-zero exit code if such failures occur, allowing `launch.bat` to catch and display these errors.

2.  **Refactor Environment Management Logic**:
    *   I removed the obsolete `deployment/env_manager.py` functionality, which had already been partially migrated to `launch.py`.
    *   I updated `deployment/models.py` to remove dependencies on the old `env_manager`.
    *   I updated `deployment/extensions.py`:
        *   Removed dependency on the old `env_manager`.
        *   Modified `ExtensionsManager` to accept the Python executable path upon initialization and added a setter for it. This allows `launch.py` to provide the correct Python path (especially from a venv).
        *   Improved error reporting by ensuring `load_extensions` and `initialize_extensions` return boolean success status.
    *   I updated `launch.py` to correctly instantiate and configure `ExtensionsManager` with the Python executable path.
    *   I ensured `launch.py` checks the return status of extension and model loading/initialization functions and propagates failures.

These changes ensure a more robust startup process where errors are correctly surfaced to you via `launch.bat`.

## Summary by Sourcery

Propagate errors in launch.py to ensure failures in subprocesses, extensions, and model downloads cause non-zero exits, and refactor environment management by removing the old env_manager and centralizing python executable handling in managers

Bug Fixes:
- Return non-zero exit codes from launch.py when backend, frontend, extension, or model operations fail
- Ensure launch.bat surfaces errors by propagating failures in subprocess management

Enhancements:
- Remove obsolete deployment/env_manager and its references in models and extensions
- Refactor ExtensionsManager to accept and use a configurable python_executable for all pip operations
- Make load_extensions and initialize_extensions report success status and handle failures in launch.py
- Refactor launch.py to check return values for model downloads and extension operations