### PR TITLE
feat: Enhance launch.bat to create Conda env if specified and missing

### DIFF
--- a/launch.bat
+++ b/launch.bat
@@ -54,9 +54,28 @@ if %errorlevel% equ 0 (
             call conda activate "%PROJECT_CONDA_ENV_NAME%"
             if !errorlevel! neq 0 (
                 echo WARNING: Failed to activate Conda environment: %PROJECT_CONDA_ENV_NAME%.
-                echo It might not exist or Conda needs setup (e.g., conda init for your shell).
-                echo Falling back to standard venv.
-                set "PROJECT_CONDA_ENV_NAME=your_conda_env_name"
+                echo Attempting to create the Conda environment...
+                call conda create -n "%PROJECT_CONDA_ENV_NAME%" python=3.9 -y
+                if !errorlevel! neq 0 (
+                    echo WARNING: Failed to create Conda environment: %PROJECT_CONDA_ENV_NAME%.
+                    echo It might not exist or Conda needs setup (e.g., conda init for your shell).
+                    echo Falling back to standard venv.
+                    set "PROJECT_CONDA_ENV_NAME=your_conda_env_name"
+                ) else (
+                    echo Successfully created Conda environment: %PROJECT_CONDA_ENV_NAME%.
+                    echo Attempting to activate the newly created environment...
+                    call conda activate "%PROJECT_CONDA_ENV_NAME%"
+                    if !errorlevel! neq 0 (
+                        echo WARNING: Failed to activate newly created Conda environment: %PROJECT_CONDA_ENV_NAME%.
+                        echo Falling back to standard venv.
+                        set "PROJECT_CONDA_ENV_NAME=your_conda_env_name"
+                    ) else (
+                        set "CONDA_ENV_ACTIVATED_BY_SCRIPT=1"
+                        set "PYTHON_EXE=%CONDA_PREFIX%\python.exe"
+                        echo Successfully activated newly created Conda environment: %PROJECT_CONDA_ENV_NAME%
+                        echo Using Python from Conda env: %PYTHON_EXE%
+                    )
+                )
             ) else (
                 set "CONDA_ENV_ACTIVATED_BY_SCRIPT=1"
                 set "PYTHON_EXE=%CONDA_PREFIX%\python.exe"


### PR DESCRIPTION
I've updated the `launch.bat` script to improve handling of Conda environments on Windows.

If `PROJECT_CONDA_ENV_NAME` is set to a specific environment name in the script, and that Conda environment does not exist (and no other Conda environment is currently active), the script will now attempt to create it using `conda create -n <name> python=3.9 -y`.

If the creation and subsequent activation are successful, this Conda environment will be used to run the application. If creation or activation fails, the script will fall back to its previous behavior of attempting to use a standard Python `venv`.

This change allows you, if you have a Conda installation, to have the project-specific Conda environment automatically created by the launch script if it's defined but not yet present.

## Summary by Sourcery

Enhance Windows launch.bat script to automatically create and activate a specified Conda environment if it doesn't exist and fall back to a standard venv on failure.

New Features:
- Automatically create and activate a missing Conda environment when PROJECT_CONDA_ENV_NAME is set and no other Conda env is active.

Enhancements:
- Define CONDA_ENV_ACTIVATED_BY_SCRIPT and PYTHON_EXE variables upon successful Conda environment activation.