### PR TITLE
Fix: Correct PowerShell venv activation in launch.bat

### DIFF
--- a/launch.bat
+++ b/launch.bat
@@ -111,13 +111,14 @@ if not defined CONDA_DEFAULT_ENV and not defined CONDA_ENV_ACTIVATED_BY_SCRIPT (
     if defined IS_POWERSHELL (
         if exist "%VENV_DIR%\Scripts\Activate.ps1" (
             echo Activating venv for PowerShell...
-            powershell -NoProfile -ExecutionPolicy Bypass -Command "& {& '%CD%\%VENV_DIR%\Scripts\Activate.ps1'; $env:ACTIVATION_SUCCESSFUL='true'}"
-            if "!ACTIVATION_SUCCESSFUL!"=="true" (
-                echo PowerShell venv activation script part executed.
+            set "ACTIVATION_STATUS="
+            FOR /F "tokens=*" %%i IN ('powershell -NoProfile -ExecutionPolicy Bypass -Command "& ""%CD%\%VENV_DIR%\Scripts\Activate.ps1""; if ($?) { Write-Host ""PS_ACTIVATE_SUCCESS"" }"') DO SET "ACTIVATION_STATUS=%%i"
+            if "!ACTIVATION_STATUS!"=="PS_ACTIVATE_SUCCESS" (
+                echo PowerShell venv activation successful.
                 set "VENV_ACTIVATED_BY_SCRIPT=1"
                 set "PYTHON_EXE=%CD%\%VENV_DIR%\Scripts\python.exe"
             ) else (
-                echo PowerShell venv activation failed or did not confirm.
+                echo PowerShell venv activation failed or script did not confirm success.
             )
         ) else (
             echo %VENV_DIR%\Scripts\Activate.ps1 not found. Cannot activate for PowerShell.


### PR DESCRIPTION
The previous method for detecting PowerShell venv activation success relied on checking an environment variable that was set within the PowerShell sub-process. This variable was not properly passed back to the parent batch script, leading to an empty variable in the `if` condition. This resulted in a syntax error: `if == "true" (` which caused the "does was unexpected at this time" error.

This commit modifies the `launch.bat` script to:
1. Change the PowerShell activation command to explicitly output a string "PS_ACTIVATE_SUCCESS" if the `Activate.ps1` script succeeds (returns exit code 0).
2. Use a `FOR /F` loop in the batch script to capture the standard output of the PowerShell command.
3. Check the captured output against the expected "PS_ACTIVATE_SUCCESS" string to determine if activation was successful.

This approach robustly communicates the success status from the PowerShell process to the batch script, resolving the syntax error and ensuring more reliable venv activation when the script is run in a PowerShell environment.