### PR TITLE
Fix: Add nltk to development requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@
 # Example:
 # pytest
 # flake8
+nltk


### PR DESCRIPTION
The application was failing during the 'dev' stage setup due to a ModuleNotFoundError for 'nltk'. This was because 'nltk' was not listed in the development requirements file.

This commit adds 'nltk' to `requirements-dev.txt` to ensure it is installed during the development environment setup, allowing the NLTK data download to proceed correctly.