### PR TITLE
Fix: Pin NLTK to v3.6.5 to resolve DownloadError

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@
 # Example:
 # pytest
 # flake8
-nltk
+nltk==3.6.5


### PR DESCRIPTION
The application was failing to initialize the 'example' extension due to an AttributeError: module 'nltk.downloader' has no attribute 'DownloadError'. This error occurs because recent versions of NLTK (3.8.1+) have removed this specific exception class.

Pinning NLTK to version 3.6.5 in `requirements-dev.txt` ensures that a version of NLTK is used where this attribute still exists, resolving the startup error. This also aligns with ensuring stability, especially given the warning about Python 3.12 support.