### PR TITLE
Fix: Improve debugging and resilience for test and build hangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,3 +306,33 @@ python launch.py --create-extension my_extension
 ```
 
 For more information about the extension system, see the [Environment Management](README_ENV_MANAGEMENT.md#extension-system) documentation.
+
+## Debugging Hangs
+
+### Debugging Pytest Hangs
+
+If `pytest` runs (e.g., via `python deployment/run_tests.py`) appear to hang:
+
+*   **Increase Verbosity**: Run `pytest` with `-vvv` (or `-vv`) for more detailed output.
+*   **Disable Capture**: Use `pytest --capture=no` to see `stdout` and `stderr` from tests in real-time. This can help identify if a test is printing lots of data or getting stuck in a loop.
+*   **Specific Test File/Function**: Try to isolate the hang by running specific test files (`pytest tests/your_test_file.py`) or specific test functions (`pytest tests/your_test_file.py::test_name`).
+*   **Debugger**: Insert `import pdb; pdb.set_trace()` (Python 3.6 and below) or `breakpoint()` (Python 3.7+) into a suspected test or fixture to step through the code.
+*   **Timeouts**: The `run_tests.py` script now includes timeouts for test suites. If a timeout occurs, it will be logged, indicating a hang in that suite.
+
+### Debugging NPM/Build Hangs
+
+If `npm run build` or other `npm` commands hang:
+
+*   **Verbose Output**: The `build` script in `package.json` has been updated to include `--debug` for Vite and `--log-level=verbose` for esbuild. Examine this output closely.
+*   **Node.js Inspector**: For debugging `node` scripts (if you suspect a specific script invoked by npm), you can try to run it with the inspector: `node --inspect-brk your_script.js`. Then connect a debugger like Chrome DevTools.
+*   **Resource Limits**: Frontend builds (especially minification, transpilation, and source map generation) can be memory and CPU intensive. Ensure your build environment (local machine, CI runner, Docker container) has adequate resources. Check for out-of-memory (OOM) errors in system logs if possible.
+*   **Clean NPM Cache/Modules**: Rarely, a corrupted npm cache or `node_modules` can cause issues. Try `npm cache clean --force` (use with caution) and remove `node_modules` and `package-lock.json`, then run `npm install` again. Note that `npm ci` (used in `Dockerfile.frontend`) is generally preferred for CI/build environments as it performs cleaner installs.
+
+### General Debugging on Linux
+
+If hangs occur in a Linux environment (like Docker containers or CI runners):
+
+*   **System Resource Monitoring**: Use tools like `top`, `htop`, or `vmstat` to check CPU, memory, and I/O usage during the suspected hang.
+*   **System Calls**: `strace -p <PID>` can attach to a running process and show system calls, which might indicate what a process is waiting for (e.g., file I/O, network).
+*   **Kernel Messages**: Check `dmesg -T` for any relevant kernel messages, such as OOM killer events.
+*   **Disk Space**: Ensure there's adequate disk space in the build environment.

--- a/deployment/Dockerfile.backend
+++ b/deployment/Dockerfile.backend
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Python dependencies
 COPY requirements.txt .
+# Ensure reliable network connectivity for pip to download packages.
+# --no-cache-dir is used to keep the image size smaller.
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
@@ -40,6 +42,8 @@ ENV APP_ENV development
 ENV NODE_ENV development
 
 # Install development dependencies
+# Ensure reliable network connectivity for pip to download packages.
+# --no-cache-dir is used to keep the image size smaller.
 RUN pip install --no-cache-dir black flake8 pylint pytest
 # Add other development dependencies as needed, e.g. from a dev-requirements.txt
 

--- a/deployment/Dockerfile.frontend
+++ b/deployment/Dockerfile.frontend
@@ -7,6 +7,8 @@ WORKDIR /app
 COPY client/package*.json ./
 
 # Install dependencies
+# npm ci is used for clean, reproducible installs based on package-lock.json.
+# Ensure network connectivity to the npm registry.
 RUN npm ci
 
 # Copy the rest of the client code
@@ -14,6 +16,9 @@ COPY client/ ./
 COPY shared/ ./shared/
 
 # Build the application
+# The npm run build process can be resource-intensive, especially for large projects.
+# Ensure the build environment has sufficient memory and CPU.
+# Using --debug as added to package.json can help if hangs occur.
 RUN npm run build
 
 # Production stage

--- a/deployment/run_tests.py
+++ b/deployment/run_tests.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("run-tests")
 # Project root directory
 PROJECT_ROOT = Path(__file__).parent.parent
 
-def run_command(command, cwd=None):
+def run_command(command, cwd=None, timeout=None):
     """Run a shell command and log the output."""
     logger.info(f"Running command: {command}")
     try:
@@ -36,14 +36,18 @@ def run_command(command, cwd=None):
             check=True,
             text=True,
             capture_output=False,  # Show output in real-time
-            cwd=cwd or str(PROJECT_ROOT)
+            cwd=cwd or str(PROJECT_ROOT),
+            timeout=timeout
         )
         return True
     except subprocess.CalledProcessError as e:
         logger.error(f"Command failed with exit code {e.returncode}")
         return False
+    except subprocess.TimeoutExpired:
+        logger.error(f"Command timed out: {command}")
+        return False
 
-def run_unit_tests(coverage=False, verbose=False):
+def run_unit_tests(coverage=False, verbose=False, timeout_seconds=900):
     """Run unit tests."""
     logger.info("Running unit tests...")
     
@@ -55,9 +59,9 @@ def run_unit_tests(coverage=False, verbose=False):
     if verbose:
         command += " -v"
     
-    return run_command(command)
+    return run_command(command, timeout=timeout_seconds)
 
-def run_integration_tests(coverage=False, verbose=False):
+def run_integration_tests(coverage=False, verbose=False, timeout_seconds=900):
     """Run integration tests."""
     logger.info("Running integration tests...")
     
@@ -69,9 +73,9 @@ def run_integration_tests(coverage=False, verbose=False):
     if verbose:
         command += " -v"
     
-    return run_command(command)
+    return run_command(command, timeout=timeout_seconds)
 
-def run_e2e_tests(verbose=False):
+def run_e2e_tests(verbose=False, timeout_seconds=1800):
     """Run end-to-end tests."""
     logger.info("Running end-to-end tests...")
     
@@ -80,7 +84,7 @@ def run_e2e_tests(verbose=False):
     if verbose:
         command += " --debug"
     
-    return run_command(command)
+    return run_command(command, timeout=timeout_seconds)
 
 def main():
     """Main entry point for the test runner script."""

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build --debug && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist --log-level=verbose",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"


### PR DESCRIPTION
This commit introduces several enhancements to mitigate and help diagnose hangs that can occur during pytest execution and npm builds.

Key changes:

1.  **`run_tests.py` Timeouts:**
    *   Added configurable timeouts to `subprocess.run()` calls for pytest unit tests (default 15 min), integration tests (default 15 min), and Playwright e2e tests (default 30 min). This prevents indefinite hangs in the test execution script.
    *   `subprocess.TimeoutExpired` exceptions are caught and logged.

2.  **NPM Build Script Enhancements (`package.json`):**
    *   The `build` script now invokes `vite build` with the `--debug` flag and `esbuild` with the `--log-level=verbose` flag. This provides more detailed output to help identify the cause of potential build hangs.

3.  **Dockerfile Updates:**
    *   Added comments to `Dockerfile.frontend` and `Dockerfile.backend` highlighting the resource-intensive nature of build steps (`npm run build`) and dependency installations (`pip install`, `npm ci`), advising on ensuring sufficient CPU/memory and reliable network connectivity.

4.  **Debugging Guidance (`README.md`):**
    *   Added a new "Debugging Hangs" section to `README.md`. This section provides actionable advice and commands for debugging hangs in pytest, npm/Node.js build processes, and general Linux environments (e.g., using `strace`, `htop`, checking `dmesg`).

These changes aim to make the development and CI processes more robust by preventing indefinite hangs and providing better tools and guidance for troubleshooting when hangs do occur.