### PR TITLE
Fix: Add uvicorn to requirements and modernize type hints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psycopg2-binary
 pyngrok>=0.7.0
 gradio
 nltk
+uvicorn>=0.34.3

--- a/server/python_nlp/gmail_service.py
+++ b/server/python_nlp/gmail_service.py
@@ -5,7 +5,7 @@ Combines metadata extraction, rate limiting, and AI training for complete email 
 
 import asyncio
 import json
-from typing import Dict, List, Optional, Any, Tuple
+from typing import Dict, List, Optional, Any
 from datetime import datetime, timedelta
 import logging
 import os # Added

--- a/server/python_nlp/nlp_engine.py
+++ b/server/python_nlp/nlp_engine.py
@@ -13,7 +13,7 @@ import os
 import re
 import sys
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from server.python_nlp.text_utils import clean_text
 from server.python_nlp.action_item_extractor import ActionItemExtractor # Import ActionItemExtractor
@@ -716,10 +716,10 @@ class NLPEngine:
         # Calculate average and cap at 0.95
         return min(total_confidence / len(analysis_results), 0.95)
 
-    def _generate_reasoning(self, 
-                           sentiment: Optional[Dict[str, Any]], 
-                           topic: Optional[Dict[str, Any]], 
-                           intent: Optional[Dict[str, Any]], 
+    def _generate_reasoning(self,
+                           sentiment: Optional[Dict[str, Any]],
+                           topic: Optional[Dict[str, Any]],
+                           intent: Optional[Dict[str, Any]],
                            urgency: Optional[Dict[str, Any]]) -> str:
         """
         Generate human-readable reasoning for the analysis results.


### PR DESCRIPTION
This commit addresses two issues:

1. Adds `uvicorn>=0.34.3` to `requirements.txt`. The `launch.py` script installs dependencies from `requirements.txt` (or `requirements_versions.txt`) but `uvicorn` was previously only listed in `pyproject.toml`. This change ensures `uvicorn` is installed in the virtual environment, resolving potential `ImportError` when starting the backend.

2. Modernizes type hints in NLP files. Removes `Tuple` from `typing` imports in `server/python_nlp/nlp_engine.py` and `server/python_nlp/gmail_service.py`. The project uses Python 3.11, where `tuple` can be used directly for type hinting. This change aligns with modern Python practices. No `Tuple[...` style annotations were found that needed conversion to `tuple[...]` in these files; the primary change was to the import statements.

## Summary by Sourcery

Include 'uvicorn' in the requirements and modernize type hints in NLP modules to align with Python 3.11

Bug Fixes:
- Add uvicorn>=0.34.3 to requirements.txt to ensure the backend can start without ImportError

Enhancements:
- Remove Tuple import from typing in NLP modules to use built-in tuple type annotations