### PR TITLE
Fix: Improve error message for npm install failures

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -729,6 +729,21 @@ def start_frontend(args: argparse.Namespace) -> Optional[subprocess.Popen]:
     client_pkg_json = client_dir / "package.json"
 
     if client_pkg_json.exists():
+        npm_executable_path = shutil.which("npm")
+        if npm_executable_path is None:
+            logger.error(
+                f"The 'npm' command was not found in your system's PATH. "
+                f"Please ensure Node.js and npm are correctly installed and that the npm installation directory is added to your PATH environment variable. "
+                f"Attempted to find 'npm' for the client in: {client_dir}"
+            )
+            # Potentially return None here if npm is essential and not found,
+            # or let it proceed to fail at the npm install line, which will now be more informed.
+            # For now, let's log and let it try, as the original code attempts to continue.
+            # If we want to stop it here, uncomment the next line:
+            # return None
+        else:
+            logger.info(f"Found 'npm' executable at: {npm_executable_path}")
+
         logger.info(f"Found package.json in {client_dir}. Running npm install...")
         try:
             # Use subprocess.run to wait for completion and check for errors


### PR DESCRIPTION
When `npm install` is run from `launch.py` for the client setup, if the `npm` command is not found in the system PATH, the generic `[WinError 2] The system cannot find the file specified` error was being logged.

This change adds a check using `shutil.which("npm")` before attempting to run `npm install`. If `npm` is not found, a more specific error message is logged, guiding you to check your Node.js/npm installation and PATH configuration.

This provides better diagnostics for you when encountering issues with frontend dependency installation on Windows.

## Summary by Sourcery

Check for the npm executable before running npm install and log a clear, user-friendly error message if npm is not found, while still attempting the original install step.

Enhancements:
- Add a pre-install check using shutil.which("npm") to detect missing npm in PATH and log guidance for installing/configuring Node.js and npm
- Log the discovered npm executable path for diagnostic purposes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved error logging to notify users if npm is not found when installing frontend dependencies, including detailed instructions for resolving the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->