### PR TITLE
Fix: Resolve critical Flake8 E999 and F821 errors

### DIFF
--- a/server/python_backend/category_routes.py
+++ b/server/python_backend/category_routes.py
@@ -35,12 +35,11 @@ async def get_categories(request: Request, db: DatabaseManager = Depends(get_db)
     except Exception as e:
         log_data = {
             "message": "Unhandled error in get_categories",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to fetch categories")
 
 
@@ -72,10 +71,9 @@ async def create_category(
     except Exception as e:
         log_data = {
             "message": "Unhandled error in create_category",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to create category")

--- a/server/python_backend/dashboard_routes.py
+++ b/server/python_backend/dashboard_routes.py
@@ -42,12 +42,11 @@ async def get_dashboard_stats(request: Request, db: DatabaseManager = Depends(ge
     except Exception as e:
         log_data = {
             "message": "Unhandled error in get_dashboard_stats",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to fetch dashboard stats")
 
 
@@ -60,10 +59,9 @@ async def get_performance_overview(request: Request):
     except Exception as e:
         log_data = {
             "message": "Unhandled error in get_performance_overview",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to fetch performance data")

--- a/server/python_backend/database.py
+++ b/server/python_backend/database.py
@@ -604,5 +604,3 @@ class DatabaseManager:
 async def get_db() -> DatabaseManager:
     """Dependency injection for database"""
     return DatabaseManager()
-
-[end of server/python_backend/database.py]

--- a/server/python_backend/email_routes.py
+++ b/server/python_backend/email_routes.py
@@ -54,12 +54,11 @@ async def get_emails(
     except Exception as e:
         log_data = {
             "message": "Unhandled error in get_emails",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to fetch emails")
 
 
@@ -91,12 +90,11 @@ async def get_email(
     except Exception as e:
         log_data = {
             "message": f"Unhandled error fetching email id {email_id}",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to fetch email")
 
 
@@ -155,12 +153,11 @@ async def create_email(
     except Exception as e:
         log_data = {
             "message": "Unhandled error in create_email",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to create email")
 
 
@@ -197,10 +194,9 @@ async def update_email(
     except Exception as e:
         log_data = {
             "message": f"Unhandled error updating email id {email_id}",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to update email")

--- a/server/python_backend/filter_routes.py
+++ b/server/python_backend/filter_routes.py
@@ -98,12 +98,11 @@ async def generate_intelligent_filters(
     except Exception as e:
         log_data = {
             "message": "Unhandled error in generate_intelligent_filters",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to generate filters")
 
 
@@ -119,10 +118,9 @@ async def prune_filters(request: Request):
     except Exception as e:
         log_data = {
             "message": "Unhandled error in prune_filters",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to prune filters")

--- a/server/python_backend/gmail_routes.py
+++ b/server/python_backend/gmail_routes.py
@@ -117,11 +117,10 @@ async def sync_gmail(
         log_data = {
             "message": "Unhandled error in sync_gmail",
             "endpoint": str(req.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(
             status_code=500,
             detail=f"Gmail sync failed due to an unexpected error: {str(e)}",
@@ -177,11 +176,10 @@ async def smart_retrieval(
         log_data = {
             "message": "Unhandled error in smart_retrieval",
             "endpoint": str(req.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(
             status_code=500,
             detail=f"Smart retrieval failed due to an unexpected error: {str(e)}",
@@ -198,12 +196,11 @@ async def get_retrieval_strategies(request: Request):
     except Exception as e:
         log_data = {
             "message": "Unhandled error in get_retrieval_strategies",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(status_code=500, detail="Failed to fetch strategies")
 
 
@@ -217,12 +214,11 @@ async def get_gmail_performance(request: Request):
     except Exception as e:
         log_data = {
             "message": "Unhandled error in get_gmail_performance",
-                    "endpoint": str(request.url),
-                    "error_type": type(e).__name__,
-                    "error_detail": str(e),
-                }
-            )
-        )
+            "endpoint": str(request.url),
+            "error_type": type(e).__name__,
+            "error_detail": str(e),
+        }
+        logger.error(json.dumps(log_data))
         raise HTTPException(
             status_code=500, detail="Failed to fetch performance metrics"
         )


### PR DESCRIPTION
This commit addresses the E999 (SyntaxError/IndentationError) and F821 (Undefined name) Flake8 errors that were identified across several Python files.

Key changes include:
- Corrected indentation errors in exception handling blocks in:
    - server/python_backend/category_routes.py
    - server/python_backend/dashboard_routes.py
    - server/python_backend/email_routes.py
    - server/python_backend/filter_routes.py
    - server/python_backend/gmail_routes.py
- Fixed a syntax error in server/python_backend/database.py.
- Resolved undefined name errors (F821) in tests/test_category_api.py by removing a duplicated and outdated test method.
- Removed unused imports (F401) and a redefined test method (F811) in tests/test_category_api.py.

I executed unit tests after these changes. While many initial test failures related to environment and basic mocking were resolved, some tests continue to fail due to complex issues with mocking asynchronous code (`TypeError: object MagicMock can't be used in 'await' expression`). These will be addressed in a separate effort.

The primary goal of eliminating the specified E999 and F821 errors has been achieved.