### PR TITLE
feat: Add --gradio-ui option to launch.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,27 @@ This typically starts:
 For other modes (e.g., API-only, frontend-only) and advanced options, see the [Launcher Guide](docs/launcher_guide.md).
 For information on running in Docker, staging, or production environments, see the [Deployment Guide](docs/deployment_guide.md).
 
+### Running the Gradio Scientific UI
+
+For scientific exploration, direct AI model interaction, or testing specific UI components, a Gradio-based interface is available. This is a Python-only, non-Dockerized deployment that runs independently of the main FastAPI backend and Node.js frontend.
+
+To launch the Gradio UI, use the `--gradio-ui` flag with the launcher script:
+
+-   On Linux/macOS:
+    ```bash
+    ./launch.sh --gradio-ui
+    ```
+-   On Windows:
+    ```bash
+    launch.bat --gradio-ui
+    ```
+
+You can also specify the host, port, and enable debug or sharing mode using the standard launcher arguments:
+    ```bash
+    ./launch.sh --gradio-ui --host 0.0.0.0 --port 7860 --debug --share
+    ```
+This will start the Gradio interface, typically accessible at the specified host and port (Gradio's default is 7860 if `--port` is not provided).
+
 ## AI System Overview
 
 The AI and NLP capabilities are primarily based on:

--- a/launch.py
+++ b/launch.py
@@ -819,7 +819,67 @@ def run_application(args: argparse.Namespace) -> int:
         else:
             logger.warning(f"Specified env file {args.env_file} not found at {env_file_path}")
 
-    if args.api_only:
+    if args.gradio_ui:
+        logger.info("Running Gradio UI for scientific/testing purposes...")
+        gradio_script_path = ROOT_DIR / "server" / "python_backend" / "gradio_app.py"
+        if not gradio_script_path.exists():
+            logger.error(f"Gradio script not found at: {gradio_script_path}")
+            return 1
+
+        cmd = [python_executable, str(gradio_script_path)]
+
+        # Pass relevant arguments to gradio_app.py
+        cmd.extend(["--host", args.host, "--port", str(args.port)])
+        if args.share: # Gradio has its own share option, pass it along
+            cmd.append("--share")
+        if args.debug:
+            cmd.append("--debug")
+        # args.listen is handled by setting args.host to "0.0.0.0" in start_backend,
+        # so passing args.host to gradio_app.py correctly handles this.
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(ROOT_DIR)
+        # Add any other necessary environment variables if gradio_app.py needs them.
+        # For example, if Gradio needs to know the API URL for some features:
+        # env["API_URL"] = f"http://{args.host}:{args.port}" # Example
+
+        try:
+            logger.info(f"Running Gradio UI command: {' '.join(cmd)}")
+            gradio_process = subprocess.Popen(cmd, env=env)
+            processes.append(gradio_process) # Add to global list for signal handling
+            # Log the access URL, considering host and port
+            # If host is 0.0.0.0, it's accessible from network, but browser link might be 127.0.0.1 or localhost
+            display_host = args.host
+            if args.host == "0.0.0.0":
+                display_host = "127.0.0.1" # Common loopback for browser access
+
+            # Gradio's default port is 7860. If args.port is not Gradio's default,
+            # and gradio_app.py is not yet modified to accept --port,
+            # the URL printed here might be misleading. Assuming gradio_app.py will be modified.
+            logger.info(f"Gradio UI started with PID {gradio_process.pid}. Expected at http://{display_host}:{args.port}. Press Ctrl+C to stop.")
+            if args.share and not ngrok_tunnel: # If --share was for Gradio directly and ngrok wasn't for backend
+                logger.info("Gradio's own share option is active. Look for a *.gradio.live URL in its output.")
+
+
+            gradio_process.wait() # Wait for the Gradio process to complete
+            # Check exit code if needed
+            if gradio_process.returncode != 0:
+                logger.warning(f"Gradio process exited with code {gradio_process.returncode}.")
+                # Depending on how critical this is, you might return 1 here.
+                # For now, let's assume it's not a launch failure unless an exception occurred.
+            return 0 # Indicate success
+        except FileNotFoundError:
+            logger.error(
+                f"Error: Python executable not found at {python_executable} or Gradio script not found at {gradio_script_path}."
+            )
+            logger.error("Ensure Gradio is installed ('pip install gradio') in the environment.")
+            return 1 # Indicate failure
+        except Exception as e:
+            logger.error(f"Failed to start Gradio UI: {e}")
+            logger.error("Ensure Gradio is installed in the environment and the script path is correct.")
+            return 1 # Indicate failure
+
+    elif args.api_only:
         logger.info("Running in API only mode.")
         backend_process = start_backend(args, python_executable)
         if backend_process:
@@ -1100,6 +1160,11 @@ def parse_arguments() -> argparse.Namespace:
         "--frontend-only",
         action="store_true",
         help="Run only the frontend without the API server",
+    )
+    parser.add_argument(
+        "--gradio-ui",
+        action="store_true",
+        help="Run only the Gradio UI for scientific/testing purposes.",
     )
     parser.add_argument("--debug", action="store_true", help="Enable debug mode")
 

--- a/server/python_backend/gradio_app.py
+++ b/server/python_backend/gradio_app.py
@@ -98,4 +98,26 @@ with gr.Blocks(title="No-Code Email Platform (Gradio UI)", theme=gr.themes.Soft(
 
 # Launch the Gradio app
 if __name__ == "__main__":
-    iface.launch()
+    import argparse
+    parser = argparse.ArgumentParser(description="Launch Gradio UI for EmailIntelligence")
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="Host to run Gradio on")
+    # Default to None for port, so Gradio can use its default (e.g., 7860) if not overridden
+    parser.add_argument("--port", type=int, default=None, help="Port to run Gradio on")
+    parser.add_argument("--debug", action="store_true", help="Enable Gradio debug mode")
+    parser.add_argument("--share", action="store_true", help="Enable Gradio sharing link (uses gradio.live)")
+
+    gradio_args = parser.parse_args()
+
+    launch_kwargs = {
+        "server_name": gradio_args.host,
+        "debug": gradio_args.debug,
+        "share": gradio_args.share
+    }
+
+    # Only add server_port to kwargs if it's actually provided,
+    # otherwise Gradio will use its default port (e.g. 7860) or the next available one.
+    if gradio_args.port is not None:
+        launch_kwargs["server_port"] = gradio_args.port
+
+    print(f"Launching Gradio UI with options: {launch_kwargs}")
+    iface.launch(**launch_kwargs)


### PR DESCRIPTION
This commit introduces a new `--gradio-ui` command-line option to the main `launch.py` script. This option allows you to directly launch the Gradio-based scientific UI (`server/python_backend/gradio_app.py`) for testing, AI model interaction, and UI component exploration.

Changes include:
- Added `--gradio-ui` argument to `launch.py`.
- Implemented logic in `run_application` within `launch.py` to execute `gradio_app.py` when `--gradio-ui` is specified.
- Modified `server/python_backend/gradio_app.py` to accept `--host`, `--port`, `--debug`, and `--share` command-line arguments, allowing its server parameters to be controlled by `launch.py`.
- Updated `README.md` to document the new `--gradio-ui` feature and its usage.

This addresses the issue where the local non-Docker Python-only scientific deployment using Gradio had "disappeared" by providing a clear, integrated way to launch it.