### PR TITLE
Merge PR #555: Relax CI thresholds and improve Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           uv run pytest tests/ src/ modules/ -v --tb=short \
             --cov=src --cov=modules --cov-report=xml --cov-report=term-missing \
-            --cov-fail-under=80
+            --cov-fail-under=70
       - name: Run Security Scans
         run: uv run bandit -r src/ modules/
       - name: Run linting
@@ -48,6 +48,7 @@ jobs:
           uv run ruff format --check src/ modules/
       - name: Type checking
         run: uv run mypy src/ modules/ --show-error-codes --no-strict-optional
+        continue-on-error: true
 
   lint-only:
     if: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,10 +19,6 @@ jobs:
         run: |
           echo "Waiting for CI checks to complete on PR #${{ github.event.pull_request.number }}"
           
-          # Extract the head branch SHA
-          PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          echo "PR Head SHA: $PR_HEAD_SHA"
-          
           # Wait for up to 10 minutes for CI to complete
           MAX_ATTEMPTS=60
           INTERVAL=10
@@ -30,13 +26,35 @@ jobs:
           for ((i=1; i<=MAX_ATTEMPTS; i++)); do
             echo "Checking CI status... (attempt $i/$MAX_ATTEMPTS)"
             
-            # Get the status of all checks for this PR
-            STATUS=$(gh pr checks "${{ github.event.pull_request.number }}" --state pending --json status -q '. | length' 2>/dev/null || echo "0")
+            # Get the status of all checks for this PR - use set +e to detect failures
+            set +e
+            STATUS=$(gh pr checks "${{ github.event.pull_request.number }}" --state pending --json status -q '. | length' 2>/dev/null)
+            STATUS_EXIT=$?
+            set -e
+            
+            # Validate we got a numeric response; fail on any error
+            if [ $STATUS_EXIT -ne 0 ] || ! echo "$STATUS" | grep -qE '^[0-9]+$'; then
+              echo "Failed to query pending checks (exit: $STATUS_EXIT, output: '$STATUS'). Retrying..."
+              sleep $INTERVAL
+              continue
+            fi
+            
             echo "Pending checks: $STATUS"
             
             if [ "$STATUS" -eq "0" ]; then
               # No more pending checks, verify all passed
-              FAILURES=$(gh pr checks "${{ github.event.pull_request.number }}" --state failure -q '. | length' 2>/dev/null || echo "0")
+              set +e
+              FAILURES=$(gh pr checks "${{ github.event.pull_request.number }}" --state failure --json status -q '. | length' 2>/dev/null)
+              FAILURES_EXIT=$?
+              set -e
+              
+              # Validate we got a numeric response; fail on any error
+              if [ $FAILURES_EXIT -ne 0 ] || ! echo "$FAILURES" | grep -qE '^[0-9]+$'; then
+                echo "Failed to query failed checks (exit: $FAILURES_EXIT, output: '$FAILURES'). Retrying..."
+                sleep $INTERVAL
+                continue
+              fi
+              
               if [ "$FAILURES" -eq "0" ]; then
                 echo "All CI checks passed!"
                 exit 0
@@ -51,6 +69,8 @@ jobs:
           
           echo "Timeout waiting for CI checks"
           exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
       - name: Auto-merge Dependabot PR
         run: |

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,17 +16,43 @@ jobs:
     
     steps:
       - name: Wait for CI checks to complete
-        uses: fountainhead/action-wait-for-check@v1.2.0
-        id: wait-for-ci
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: test
-          ref: ${{ github.event.pull_request.head.sha }}
-          timeoutSeconds: 600
-          intervalSeconds: 10
+        run: |
+          echo "Waiting for CI checks to complete on PR #${{ github.event.pull_request.number }}"
+          
+          # Extract the head branch SHA
+          PR_HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          echo "PR Head SHA: $PR_HEAD_SHA"
+          
+          # Wait for up to 10 minutes for CI to complete
+          MAX_ATTEMPTS=60
+          INTERVAL=10
+          
+          for ((i=1; i<=MAX_ATTEMPTS; i++)); do
+            echo "Checking CI status... (attempt $i/$MAX_ATTEMPTS)"
+            
+            # Get the status of all checks for this PR
+            STATUS=$(gh pr checks "${{ github.event.pull_request.number }}" --state pending --json status -q '. | length' 2>/dev/null || echo "0")
+            echo "Pending checks: $STATUS"
+            
+            if [ "$STATUS" -eq "0" ]; then
+              # No more pending checks, verify all passed
+              FAILURES=$(gh pr checks "${{ github.event.pull_request.number }}" --state failure -q '. | length' 2>/dev/null || echo "0")
+              if [ "$FAILURES" -eq "0" ]; then
+                echo "All CI checks passed!"
+                exit 0
+              else
+                echo "Some CI checks failed."
+                exit 1
+              fi
+            fi
+            
+            sleep $INTERVAL
+          done
+          
+          echo "Timeout waiting for CI checks"
+          exit 1
         
       - name: Auto-merge Dependabot PR
-        if: steps.wait-for-ci.outputs.conclusion == 'success'
         run: |
           set -e
           echo "CI checks passed. Auto-merging Dependabot PR #${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

This PR resolves the merge conflicts in PR #555 and merges the changes from the original PR branch (`fix/dependabot-auto-merge-ci`) into main.

### Changes Applied

1. **CI Workflow (`.github/workflows/ci.yml`)**:
   - Reduced coverage threshold from 80% to 70%
   - Added `continue-on-error: true` to mypy type checking

2. **Dependabot Auto-Merge Workflow (`.github/workflows/dependabot-auto-merge.yml`)**:
   - Replaced problematic fountainhead action with native `gh pr checks`
   - Improved wait logic to properly check all CI status states
   - Added timeout handling - waits up to 10 minutes with 10-second intervals

### Resolution Method

Since the PR branch had extensive divergence from main with 230+ conflicting files (mostly due to structural reorganization), I used a targeted cherry-pick approach to extract only the relevant workflow changes and apply them to a clean branch. This avoids the complexity of resolving all other merge conflicts unrelated to PR #555's purpose.

This approach ensures the CI improvements from PR #555 are preserved while keeping the rest of the repository consistent with main.

## Summary by Sourcery

Relax CI requirements and improve the Dependabot auto-merge workflow to better handle CI check completion and failures.

Build:
- Lower the test coverage failure threshold from 80% to 70% in the main CI workflow and allow mypy type-checking failures without failing the job.

CI:
- Replace the third-party wait-for-check GitHub Action in the Dependabot auto-merge workflow with a custom script using `gh pr checks`, adding robust polling, failure detection, and a 10-minute timeout before auto-merging.