### PR TITLE
⚡ Bolt: Debounce search input to reduce API calls

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -13,7 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { Search, FolderSync, Filter } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { Category, EmailWithCategory } from "@shared/schema";
 
 /**
@@ -28,16 +28,25 @@ import type { Category, EmailWithCategory } from "@shared/schema";
  */
 export default function Dashboard() {
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const [syncLoading, setSyncLoading] = useState(false);
   const [selectedEmail, setSelectedEmail] = useState<EmailWithCategory | null>(null);
   const { toast } = useToast();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery);
+    }, 300);
+
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
   const { data: categories = [] } = useQuery<Category[]>({
     queryKey: ["/api/categories"],
   });
 
   const { data: emails = [], isLoading: emailsLoading, refetch: refetchEmails } = useQuery<EmailWithCategory[]>({
-    queryKey: ["/api/emails", searchQuery ? { search: searchQuery } : {}],
+    queryKey: ["/api/emails", debouncedSearchQuery ? { search: debouncedSearchQuery } : {}],
   });
 
   /**


### PR DESCRIPTION
💡 What: Implemented a 300ms debounce on the `searchQuery` state in `client/src/pages/dashboard.tsx`.
🎯 Why: Typing in the search bar previously triggered an API request (`/api/emails`) for every keystroke because `searchQuery` was directly tied to the `useQuery` hook. This caused unnecessary API calls, increased server load, and sluggish UI interactions.
📊 Impact: Significantly reduces the number of API calls. The search will now only trigger after the user stops typing for 300ms, representing a huge reduction in requests for users who type quickly.
🔬 Measurement: Can be verified by observing the Network tab while typing in the dashboard search bar. There should be only one request 300ms after typing stops, instead of a burst of requests.
📝 Notes: `pnpm lint` and `tsc` were unavailable in the validation step, but the code modifications are fully sound and types are maintained. Unrelated dependencies in `uv.lock` were carefully excluded from this PR.

---
*PR created automatically by Jules for task [11171452089317330802](https://jules.google.com/task/11171452089317330802) started by @MasumRab*

## Summary by Sourcery

Enhancements:
- Introduce a debounced search query state so email fetching is triggered only after 300ms of inactivity instead of on every keystroke.