### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in email content path

### DIFF
--- a/src/backend/python_backend/database.py
+++ b/src/backend/python_backend/database.py
@@ -107,6 +107,11 @@ class DatabaseManager:
             logger.info(f"Created email content directory: {self.email_content_dir}")
 
     def _get_email_content_path(self, email_id: int) -> str:
+        try:
+            email_id = int(email_id)
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid email_id format: {email_id}")
+
         return os.path.join(self.email_content_dir, f"{email_id}.json.gz")
 
     async def _load_and_merge_content(self, email_light: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/backend/python_backend/email_data_manager.py
+++ b/src/backend/python_backend/email_data_manager.py
@@ -60,6 +60,11 @@ class EmailDataManager:
 
     def _get_email_content_path(self, email_id: int) -> str:
         """Returns the path for an individual email's content file."""
+        try:
+            email_id = int(email_id)
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid email_id format: {email_id}")
+
         return os.path.join(self.email_content_dir, f"{email_id}.json.gz")
 
     async def _load_and_merge_content(self, email_light: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/backend/python_backend/json_database.py
+++ b/src/backend/python_backend/json_database.py
@@ -110,6 +110,11 @@ class JSONDataManager:
 
     def _get_email_content_path(self, email_id: int) -> str:
         """Returns the path for an individual email's content file."""
+        try:
+            email_id = int(email_id)
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid email_id format: {email_id}")
+
         return os.path.join(self.email_content_dir, f"{email_id}.json.gz")
 
     async def _load_and_merge_content(self, email_light: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/core/database.py
+++ b/src/core/database.py
@@ -171,6 +171,11 @@ class DatabaseManager(DataSource):
 
     def _get_email_content_path(self, email_id: int) -> str:
         """Returns the path for an individual email's content file."""
+        try:
+            email_id = int(email_id)
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid email_id format: {email_id}")
+
         return os.path.join(self.email_content_dir, f"{email_id}.json.gz")
 
     def _read_content_sync(self, content_path: str) -> Dict[str, Any]:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_get_email_content_path` method across four database implementations in `src/core/database.py`, `src/backend/python_backend/database.py`, `src/backend/python_backend/email_data_manager.py`, and `src/backend/python_backend/json_database.py` constructs file paths by appending `email_id` directly to the content directory. An attacker submitting an `email_id` such as `"../../../etc/passwd"` could read unauthorized files if the system fails to validate or enforce type safety. 
🎯 Impact: Exploitation of this vulnerability could lead to arbitrary file reads (Path Traversal), exposing sensitive configuration or system files.
🔧 Fix: Add strict type-casting using `int(email_id)` inside the path construction method. If the input contains a path traversal string, the cast fails and correctly raises a `ValueError`, eliminating the traversal risk entirely before any file operation occurs.
✅ Verification: Tested the fix against a traversal payload string `"../../../etc/passwd"`, which correctly triggers a `ValueError: invalid literal for int()`. Also ran tests (`uv run --with fastapi --with pytest --with pytest-asyncio pytest tests/core/test_security.py`) to confirm no new regressions.
📝 Notes: Fixed the issue natively using standard Python built-ins without any new dependencies or heavy architectural changes. Avoided adding any untracked or scratchpad files, and specifically ensured `uv.lock` and other configurations remained unmodified.

---
*PR created automatically by Jules for task [7692854003959057341](https://jules.google.com/task/7692854003959057341) started by @MasumRab*

## Summary by Sourcery

Bug Fixes:
- Validate and cast email_id to an integer before constructing email content file paths across core and backend database components, rejecting malformed or traversal-style input with a ValueError.