### PR TITLE
🛡️ Sentinel: [MEDIUM] Enforce secure timezone-aware datetimes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-12 - [MEDIUM] Enforce secure timezone-aware datetimes
+**Vulnerability:** Deprecated and timezone-naive `datetime.utcnow()` usage across authentication and context models.
+**Learning:** The codebase previously relied on `datetime.utcnow()`, which in Python 3.12+ is deprecated and yields timezone-naive objects. When passed around or used in token claims, naive datetimes can introduce subtle validation bugs.
+**Prevention:** Replace all occurrences of `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)`. For Pydantic models, use a module-level `utc_now` helper function as the `default_factory`.

--- a/src/backend/python_backend/auth.py
+++ b/src/backend/python_backend/auth.py
@@ -4,7 +4,7 @@ Authentication and authorization system for the Email Intelligence Platform.
 This module implements JWT-based authentication for API endpoints.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import jwt
@@ -27,9 +27,9 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     """Create a JWT access token with the provided data."""
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     return encoded_jwt

--- a/src/context_control/models.py
+++ b/src/context_control/models.py
@@ -2,8 +2,10 @@
 
 from typing import Dict, List, Optional, Any
 from pydantic import BaseModel, Field
-from datetime import datetime
+from datetime import datetime, timezone
 
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
 
 class ProjectConfig(BaseModel):
     """Project-specific configuration settings."""
@@ -40,8 +42,8 @@ class ProjectConfig(BaseModel):
     )
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
 
     class Config:
         """Pydantic configuration."""
@@ -82,8 +84,8 @@ class ContextProfile(BaseModel):
     )
 
     # Metadata
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
     version: str = Field(default="1.0.0", description="Profile version")
 
     class Config:
@@ -126,7 +128,7 @@ class AgentContext(BaseModel):
     is_active: bool = Field(
         default=True, description="Whether this context is currently active"
     )
-    activated_at: datetime = Field(default_factory=datetime.utcnow)
+    activated_at: datetime = Field(default_factory=utc_now)
     last_validated: Optional[datetime] = Field(None)
 
     # Security tracking
@@ -150,5 +152,5 @@ class ContextValidationResult(BaseModel):
     warnings: List[str] = Field(default_factory=list, description="Validation warnings")
 
     # Additional metadata
-    validated_at: datetime = Field(default_factory=datetime.utcnow)
+    validated_at: datetime = Field(default_factory=utc_now)
     context_id: Optional[str] = Field(None, description="ID of the validated context")

--- a/src/core/auth.py
+++ b/src/core/auth.py
@@ -5,7 +5,7 @@ This module implements JWT-based authentication for API endpoints and integrates
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any, List
 import time
 import secrets
@@ -66,9 +66,9 @@ def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -
     """
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, settings.secret_key, algorithm=settings.algorithm)
     return encoded_jwt


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: `datetime.utcnow()` has been deprecated in Python 3.12+ and produces timezone-naive objects. Utilizing naive UTC datetimes for authentication, tokens, context timestamps, or expiration checks can inadvertently lead to bugs and subtle validation flaws.
🎯 Impact: This improves robustness, preventing potential timezone validation issues.
🔧 Fix: Replaced `datetime.utcnow()` with the timezone-aware `datetime.now(timezone.utc)`. Included custom module-level `utc_now()` function for usage with Pydantic `default_factory`.
✅ Verification: Tested via unit tests with `uv run pytest tests/test_basic.py` which succeed securely.
📝 Notes: Pushed changes to an existing PR addressing this exact problem, bypassing the lockfile-pollution observed earlier in CI.

---
*PR created automatically by Jules for task [2140584468424237267](https://jules.google.com/task/2140584468424237267) started by @MasumRab*

## Summary by Sourcery

Replace naive UTC datetime usage with timezone-aware UTC datetimes across authentication logic and context models to improve robustness and future compatibility.

Bug Fixes:
- Ensure JWT expiration timestamps use timezone-aware UTC datetimes instead of deprecated naive `datetime.utcnow()` values.
- Ensure context and project metadata timestamps in Pydantic models use timezone-aware UTC datetimes to avoid subtle timezone-related bugs.

Enhancements:
- Introduce a shared `utc_now` helper for consistent timezone-aware default timestamps in Pydantic models.

Documentation:
- Add a Sentinel note documenting the datetime vulnerability, its impact, and the standardized mitigation pattern for future changes.